### PR TITLE
fix inconsistent alloc style for gs_xlates

### DIFF
--- a/Descent3/demofile.cpp
+++ b/Descent3/demofile.cpp
@@ -862,8 +862,8 @@ int DemoReadHeader()
 	Demo_next_frame = demo_gametime;
 
 	if (gs_Xlates)
-		mem_free(gs_Xlates);
-	gs_Xlates = (struct gs_tables *)mem_malloc(sizeof(gs_tables));
+		delete (gs_Xlates);
+	gs_Xlates = new gs_tables;
 
 	try
 	{
@@ -1609,7 +1609,7 @@ void DemoAbort(bool deletefile)
 	if(Demo_flags != DF_NONE)
 	{
 		//We're done with the xlate table, so free it
-		mem_free(gs_Xlates);
+		delete (gs_Xlates);
 		gs_Xlates = NULL;
 
 		cfclose(Demo_cfp);

--- a/Descent3/loadstate.cpp
+++ b/Descent3/loadstate.cpp
@@ -408,6 +408,7 @@ START_VERIFY_SAVEFILE(fp);
 
 loadsg_error:
 	delete gs_Xlates;
+	gs_Xlates = nullptr;
 
 	END_VERIFY_SAVEFILE(fp, "Total load");	
 	cfclose(fp);


### PR DESCRIPTION
this variable was causing a crash after doing the following steps without asan:
* load a level
* exit the level
* enter secret2.dem

effectively the bug was a double-free because gs_xlates wasn't being set to null after deallocating, but using mem_malloc and new inconsistently didn't help. this fixes the crash!