### PR TITLE
Account for changes in FOV in object rendering

### DIFF
--- a/Descent3/renderobject.cpp
+++ b/Descent3/renderobject.cpp
@@ -1955,19 +1955,28 @@ int IsPointVisible (vector *pos,float size,float *pointz)
 		if (Render_FOV!=last_render_fov)
 		{
 			last_render_fov=Render_FOV;
-			int angle_adjust=(Render_FOV/2)*(65536/360);
+			int vfov=(Render_FOV/2)*(65536/360);
+
+			int w, h;
+			rend_GetProjectionParameters( &w, &h );
+
+			float aspect = (float) w / (float) h;
+			float up = tan(Render_FOV/2.0);
+			float side = up * aspect;
+			float hfov = atan(side) * 65536.0 / 3.14159;
+
 			vector rvec={1,0,0};
 			vector lvec={-1,0,0};
 			vector tvec={0,1,0};
 			vector bvec={0,-1,0};
 			matrix temp_mat;
-			vm_AnglesToMatrix (&temp_mat,0,65536-angle_adjust,0);
+			vm_AnglesToMatrix (&temp_mat,0,65536-hfov,0);
 			right_normal=rvec*temp_mat;
-			vm_AnglesToMatrix (&temp_mat,0,angle_adjust,0);
+			vm_AnglesToMatrix (&temp_mat,0,hfov,0);
 			left_normal=lvec*temp_mat;
-			vm_AnglesToMatrix (&temp_mat,65536-angle_adjust,0,0);
+			vm_AnglesToMatrix (&temp_mat,65536-vfov,0,0);
 			bottom_normal=bvec*temp_mat;
-			vm_AnglesToMatrix (&temp_mat,angle_adjust,0,0);
+			vm_AnglesToMatrix (&temp_mat,vfov,0,0);
 			top_normal=tvec*temp_mat;
 		}
 		// Get unscaled matrix stuff


### PR DESCRIPTION
Since Render_FOV is now a vertical value instead of a horizontal one, object culling is wrong.
It assumes that you're on a 4:3 screen thus the FOV is on the larger horizontal dimension for purposes of culling, then pretends the screen is just square from that. 

I chagned the normals used for culling accounting for the fact that Render_fov is vertical and that we have to calculate the left and right normals based off aspect ratio.

Results seem promising!